### PR TITLE
[Merged]ログイン画面・ログアウト画面を追加

### DIFF
--- a/diapp/lib/main.dart
+++ b/diapp/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:diapp/model/OnMemory.dart';
 import 'package:diapp/utils/AuthAccess.dart';
 import 'package:diapp/utils/FirebaseSettings.dart';
+import 'package:diapp/view/BeforeLoginWidget.dart';
 import 'package:diapp/view/CalendarWidget.dart';
 import 'package:diapp/view/TabWidget.dart';
 import 'package:flutter/material.dart';
@@ -25,7 +26,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const TabPage(),
+      home: BeforeLoginPage(),
     );
   }
 }

--- a/diapp/lib/utils/AuthAccess.dart
+++ b/diapp/lib/utils/AuthAccess.dart
@@ -13,18 +13,32 @@ class AuthAccess {
 
   AuthAccess._internal() {}
 
-  Future signIn(String id, String pass) async {
+  // サインイン処理
+  // 引数のID・passwordに対してログイン処理を実施
+  // 戻り値 正常の場合はnull ・異常の場合はエラーコード文字列を返す
+  Future<String?> signIn(String id, String pass) async {
     try {
-      print("signIn: start");
-       await _authInstance.signInWithEmailAndPassword(
+      await _authInstance.signInWithEmailAndPassword(
         email: id,
         password: pass,
       );
-      print("signIn: SUCCESS");
+      return null;
     }
     on FirebaseAuthException catch (e) {
-      print("signIn: ERROR");
-      print("エラーコード: ${ e.code }");
+      print("signIn エラーコード: ${ e.code }");
+      return e.code;
+    }
+  }
+
+  // サインアウト処理
+  // 戻り値 正常の場合はnull ・異常の場合はエラーコード文字列を返す
+  Future signOut() async {
+    try {
+      return await _authInstance.signOut();
+    }
+    on FirebaseAuthException catch (e) {
+      print("signOut エラーコード: ${ e.code }");
+      return e.code;
     }
   }
 }

--- a/diapp/lib/utils/DialogBuilder.dart
+++ b/diapp/lib/utils/DialogBuilder.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class DialogBuilder {
+
+  static final DialogBuilder _instance = DialogBuilder._internal();
+
+  factory DialogBuilder() {
+    return _instance;
+  }
+
+  DialogBuilder._internal() {}
+
+  void showSingleDialog(BuildContext context,String title, String message) {
+    showDialog(context: context, builder: (_) {
+      return _alertSingleBuilder(context, title, message);
+    });
+  }
+
+  AlertDialog _alertSingleBuilder(BuildContext context, String title, String message) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+            onPressed: () {
+              Navigator.pop(context, 'OK');
+            },
+            child: const Text('OK'))
+      ],);
+  }
+}
+

--- a/diapp/lib/view/BeforeLoginWidget.dart
+++ b/diapp/lib/view/BeforeLoginWidget.dart
@@ -1,0 +1,156 @@
+import 'dart:ffi';
+
+import 'package:diapp/utils/AuthAccess.dart';
+import 'package:diapp/utils/DialogBuilder.dart';
+import 'package:diapp/utils/FirebaseSettings.dart';
+import 'package:diapp/view/TabWidget.dart';
+import 'package:flutter/material.dart';
+
+class BeforeLoginPage extends StatefulWidget {
+  const BeforeLoginPage({super.key});
+
+  @override
+  State<BeforeLoginPage> createState() => _BeforeLoginState();
+}
+
+class _BeforeLoginState extends State<BeforeLoginPage> {
+
+  var _inputUserId = "";
+  var _inputPassword = "";
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+          title: Text("設定"),
+        ),
+        body: Column(
+            children: <Widget>[
+                Container(
+                    child: Row(
+                      children: [
+                        SizedBox(
+                          width: 20,
+                        ),
+                        Container(
+                            width: 30,
+                            height: 30,
+                            child: Icon(Icons.account_circle)
+                        ),
+                        SizedBox(
+                          width: 20,
+                        ),
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            "ログイン画面",
+                            style: TextStyle(
+                              color: Colors.black87,
+                              fontSize: 30,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                ),
+              SizedBox(
+                height: 10,
+              ),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  "User ID",
+                  style: TextStyle(
+                    color: Colors.black87,
+                    fontSize: 20,
+                  ),
+                ),
+              ),
+              SizedBox(
+                height: 10,
+              ),
+              userIdTextField(),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  "Password",
+                  style: TextStyle(
+                    color: Colors.black87,
+                    fontSize: 20,
+                  ),
+                ),
+              ),
+              SizedBox(
+                height: 10,
+              ),
+              passwordTextField(),
+              InkWell(
+                onTap: () async {
+                  var errorCode = await confirmLogin();
+
+                  if (errorCode == null) {
+                    // 画面遷移
+                    Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => TabPage()));
+                  } else {
+                    DialogBuilder().showSingleDialog(context, "エラー", "ログインできませんでした\n(" + errorCode + ")");
+                  }
+                },
+                child:
+                Container(
+                    child: Row(
+                      children: [
+                        SizedBox(
+                          height: 120,
+                        ),
+                        Align(
+                          alignment: Alignment.center,
+                          child: Text(
+                            "ログイン",
+                            style: TextStyle(
+                              color: Colors.black87,
+                              fontSize: 30,
+                            ),
+                          ),
+                        ),
+                      ],
+                    )
+                ),
+              )
+            ]
+        ));
+  }
+
+  TextField userIdTextField() {
+    return TextField(
+        decoration: InputDecoration(
+          hintText: 'User ID',
+        ),
+        onChanged: (text) {
+          _inputUserId = text;
+        }
+    );
+  }
+
+    TextField passwordTextField() {
+      return TextField(
+          decoration: InputDecoration(
+            hintText: 'password',
+          ),
+          onChanged: (text) {
+            _inputPassword = text;
+          }
+      );
+  }
+
+  // ログイン実施
+  Future<String?> confirmLogin() async {
+    try {
+      AuthAccess auth = AuthAccess();
+      return await auth.signIn(_inputUserId, _inputPassword);
+    } catch (e) {
+      return e.toString();
+    }
+  }
+
+}

--- a/diapp/lib/view/SettingWidget.dart
+++ b/diapp/lib/view/SettingWidget.dart
@@ -1,5 +1,6 @@
 import 'package:diapp/utils/AuthAccess.dart';
 import 'package:diapp/utils/FirebaseSettings.dart';
+import 'package:diapp/view/BeforeLoginWidget.dart';
 import 'package:flutter/material.dart';
 
 class SettingPage extends StatefulWidget {
@@ -21,15 +22,9 @@ class _SettingPageState extends State<SettingPage> {
             children: <Widget>[
               InkWell(
                 onTap: () async {
-                  try {
-                  // User Registration
-                  AuthAccess auth = AuthAccess();
-                  await auth.signIn("diapp0227@gmail.com", "hogehoge");
-                  } catch (e) {
-                  // Failed User Information
-                  print("エラーコード: ${ e }");
-                  }
-                },
+                  await AuthAccess().signOut();
+                  Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => BeforeLoginPage()));
+                },// User Registration
                 child:
                 Container(
                     child: Row(


### PR DESCRIPTION
# やったこと
* ログイン画面を追加
  * ID・パスワードを入力できるテキストフィールドを追加
  * 「ログイン」ボタン押下でFirebase Authcationの サインインAPIを実施する
    *  ログイン成功した場合は、画面遷移
    * ログイン失敗した場合は、エラーダイアログ表示
* 設定タブの「ログアウト」ボタン押下時は、ログイン画面に遷移する

# 動画
https://github.com/diapp0227/diapp_flutter/assets/161457009/4098018b-c30d-4ced-ad57-4a545542f4f4

# 参考
* firebase_authのAPI参考
https://zenn.dev/musuke/articles/7842c3981bf373b116e3

* 画面遷移方法
https://note.com/blue_69/n/n3ad86b058b49 (使ったのはこっち)
https://qiita.com/motoki418/items/188ac56475ae7d48dcdf

 * ダイアログ表示
https://qiita.com/coka__01/items/4c1aea5fb1646e463f91